### PR TITLE
Disable ALWAYS_SEARCH_USER_PATHS

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -135,3 +135,6 @@ TEST_AFTER_BUILD = NO
 
 // Disable GCC compatibility warnings
 WARNING_CFLAGS = -Wno-gcc-compat
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO


### PR DESCRIPTION
As far as I can tell this flag does two things:
1. Looks in USER_HEADER_SEARCH_PATHS before HEADER_SEARCH_PATHS for both quoted and bracketed includes. This is so you can override system headers with your own versions of the same headers by adding them to USER_HEADER_SEARCH_PATHS.
2. Enables Xcode magic includes, letting you include any project header with quoted includes regardless of it's position in the file system hierarchy (`"header_in_another_folder.h"`), and any subproject header with bracketed includes, regardless of whether the subproject even exports it and copies it to the build directory (`<subproject/private_unexported_header.h>`).

The first point seems weird to me. I feel like the correct way of doing that would be to specify your system headers overrides in HEADER_SEARCH_PATHS instead.

The second point leaves me baffled, in fact I'm not even sure it's as I understood it, because if it is, it's pretty crazy.

Anyway, the documentation of this flag says it's enabled by default for backwards compatibility, and strongly recommends disabling it, so there.
