### PR TITLE
Added uninstalled products header search path to iOS.

### DIFF
--- a/iOS/iOS-Base.xcconfig
+++ b/iOS/iOS-Base.xcconfig
@@ -15,7 +15,7 @@ SDKROOT = iphoneos
 SKIP_INSTALL = YES
 
 // Xcode needs this to find archived headers if SKIP_INSTALL is set
-HEADER_SEARCH_PATHS = $(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include
+HEADER_SEARCH_PATHS = $(OBJROOT)/UninstalledProducts/include
 
 // Supported SDK platforms
 SUPPORTED_PLATFORMS = iphonesimulator iphoneos


### PR DESCRIPTION
Since the iOS configs set `SKIP_INSTALL` they should include the workaround for the Xcode being silly because of it.
