### PR TITLE
Update Common.xcconfig with warnings suggested by Xcode5

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -47,6 +47,9 @@ CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
 // For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
 CLANG_WARN_INT_CONVERSION = YES;
 
+// Warn about repeatedly using a weak reference without assigning the weak reference to a strong reference.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES
+
 // Warn about classes that unintentionally do not subclass a root class (such as NSObject).
 CLANG_WARN_OBJC_ROOT_CLASS = YES
 


### PR DESCRIPTION
New Xcode enables a few new warnings by default. This PR adjusts Common.xcconfig accordingly.
