### PR TITLE
fix warning not recognized in recent Xcode

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -45,7 +45,7 @@ CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
 
 // Warn about implicit conversions between pointers and integers.
 // For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
-CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_INT_CONVERSION = YES
 
 // Warn about repeatedly using a weak reference without assigning the weak reference to a strong reference.
 CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES


### PR DESCRIPTION
Seems the trailing semicolon confuses Xcode 5,
as the setting which has it and the following
one are somewhat misinterpreted. With the
semicolon they're only applied to Debug / Release
configuration but not to the other. Removing
the semicolon fixes that.

I wasn't aware of it in the previous "cleanup" commit, but just
found this by accident when 'weak' warnings didn't show up in 
Debug builds but only in Release builds.
