### PR TITLE
Don't warn about weak refs

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -47,8 +47,8 @@ CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
 // For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
 CLANG_WARN_INT_CONVERSION = YES
 
-// Warn about repeatedly using a weak reference without assigning the weak reference to a strong reference.
-CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES
+// Don't warn about repeatedly using a weak reference without assigning the weak reference to a strong reference. Too many false positives.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO
 
 // Warn about classes that unintentionally do not subclass a root class (such as NSObject).
 CLANG_WARN_OBJC_ROOT_CLASS = YES


### PR DESCRIPTION
This warning is great in theory but, it turns out, really annoying in practice. There are a lot of instances (e.g., weak outlets) where you know the reference won't be dealloc'd while you're using it. This just forces unnecessary strong refs or ugly pragmas to turn it off.

/cc @diederich
