### PR TITLE
Look for user headers in the project folder first

### DIFF
--- a/Base/Targets/StaticLibrary.xcconfig
+++ b/Base/Targets/StaticLibrary.xcconfig
@@ -11,11 +11,12 @@ DEAD_CODE_STRIPPING = NO
 // disabled for library code)
 GCC_DYNAMIC_NO_PIC = NO
 
-// When compiling this library, look for imports in the library's own folder
-// first. This avoids conflicts from other headers in the build folder.
-HEADER_SEARCH_PATHS = ./**
-
 // Copy headers to "include/LibraryName" in the build folder by default. This
 // lets consumers use #import <LibraryName/LibraryName.h> syntax even for static
 // libraries
 PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME
+
+// When compiling this library, look for imports (written with quotes) in the
+// library's own folder first. This avoids conflicts from other headers in the
+// build folder.
+USER_HEADER_SEARCH_PATHS = ./**

--- a/Mac OS X/Mac-Framework.xcconfig
+++ b/Mac OS X/Mac-Framework.xcconfig
@@ -14,12 +14,13 @@ DEAD_CODE_STRIPPING = NO
 // disabled for library code)
 GCC_DYNAMIC_NO_PIC = NO
 
-// When compiling this framework, look for imports in the library's own folder
-// first. This avoids conflicts from other headers in the build folder.
-HEADER_SEARCH_PATHS = ./**
-
 // Enables the framework to be included from any location as long as the
 // loader’s runpath search paths includes it. For example from an application
 // bundle (inside the "Frameworks" folder) or shared folder
 INSTALL_PATH = @rpath
 LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
+
+// When compiling this library, look for imports (written with quotes) in the
+// library's own folder first. This avoids conflicts from other headers in the
+// build folder.
+USER_HEADER_SEARCH_PATHS = ./**


### PR DESCRIPTION
If two copies of the same library or framework are used in an application, and both install their headers into the build products folder, their imports will start conflicting.

By using this build setting, and switching to quoted imports within the library, headers are looked for within the library source tree first.
