### PR TITLE
(re)enable generation of debug symbols for iOS static libraries

### DIFF
--- a/iOS/iOS-StaticLibrary.xcconfig
+++ b/iOS/iOS-StaticLibrary.xcconfig
@@ -10,12 +10,14 @@
 // Apply common settings specific to iOS
 #include "iOS-Base.xcconfig"
 
-// Supported device families (1 is iPhone, 2 is iPad)
-TARGETED_DEVICE_FAMILY = 1,2
-
-// reenable generation of debug symbols, and disable stripping, so symbols
-// are available when linking the final application and in the apps dSYM 
-// (was disabled by Release/Profile settings)
-GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+// overwrite from Release.xcconfig
 COPY_PHASE_STRIP = NO
 
+// Whether to generate debugging symbols
+// overwrite from Release.xcconfig
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
+// Supported device families (1 is iPhone, 2 is iPad)
+TARGETED_DEVICE_FAMILY = 1,2


### PR DESCRIPTION
Debug symbols are disabled in Release builds by default,
but should be enabled for (iOS-)static libraries, so that the symbols end up in the app's dSYMs
