### PR TITLE
always generate Debug symbols

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -68,6 +68,9 @@ GCC_C_LANGUAGE_STANDARD = gnu99
 // Whether to enable exceptions for Objective-C
 GCC_ENABLE_OBJC_EXCEPTIONS = YES
 
+// Whether to generate debugging symbols
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
 // Whether to precompile the prefix header (if one is specified)
 GCC_PRECOMPILE_PREFIX_HEADER = YES
 

--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -9,9 +9,6 @@
 // binaries)
 COPY_PHASE_STRIP = NO
 
-// Whether to generate debugging symbols
-GCC_GENERATE_DEBUGGING_SYMBOLS = YES
-
 // The optimization level (0, 1, 2, 3, s) for the produced binary
 GCC_OPTIMIZATION_LEVEL = 0
 

--- a/Base/Configurations/Profile.xcconfig
+++ b/Base/Configurations/Profile.xcconfig
@@ -13,9 +13,6 @@
 // binaries)
 COPY_PHASE_STRIP = NO
 
-// Whether to generate debugging symbols
-GCC_GENERATE_DEBUGGING_SYMBOLS = YES
-
 // Whether to only build the active architecture
 ONLY_ACTIVE_ARCH = YES
 

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -9,9 +9,6 @@
 // binaries)
 COPY_PHASE_STRIP = YES
 
-// Whether to generate debugging symbols
-GCC_GENERATE_DEBUGGING_SYMBOLS = NO
-
 // The optimization level (0, 1, 2, 3, s) for the produced binary
 GCC_OPTIMIZATION_LEVEL = s
 

--- a/Base/Targets/StaticLibrary.xcconfig
+++ b/Base/Targets/StaticLibrary.xcconfig
@@ -17,11 +17,6 @@ COPY_PHASE_STRIP = NO
 // disabled for library code)
 GCC_DYNAMIC_NO_PIC = NO
 
-// Whether to generate debugging symbols.
-//
-// Overrides Release.xcconfig when used at the target level.
-GCC_GENERATE_DEBUGGING_SYMBOLS = YES
-
 // Copy headers to "include/LibraryName" in the build folder by default. This
 // lets consumers use #import <LibraryName/LibraryName.h> syntax even for static
 // libraries


### PR DESCRIPTION
In order to symbolicate crashes, we need to keep the dSYMs around.
Even or especially from Release builds. This commits enables generation
of debug symbols for all targets & configurations.
http://stackoverflow.com/a/12827463/206393 looks like a good read on
this topic.

refs libgit2/objective-git#210
