### PR TITLE
Specify the ARCHS manually for iOS targets

### DIFF
--- a/iOS/iOS-Base.xcconfig
+++ b/iOS/iOS-Base.xcconfig
@@ -5,7 +5,9 @@
 //
 
 // Architectures to build
-ARCHS = $(ARCHS_STANDARD_32_BIT)
+// Xcode 5 doesn't know about ARCHS_STANDARD_32_BIT
+// And Xcode 4 doesn't know about ARCHS_STANDARD
+ARCHS = armv7 armv7s
 
 // Whether to only build the active architecture (overridden from Debug/Profile)
 ONLY_ACTIVE_ARCH = NO


### PR DESCRIPTION
This is to support both Xcode 4 and Xcode 5.

Xcode 5 doesn't know about ARCHS_STANDARD_32_BIT
and Xcode 4 doesn't know about ARCHS_STANDARD

:rage:
