### PR TITLE
Add arm64 to ARCHS

### DIFF
--- a/iOS/iOS-Base.xcconfig
+++ b/iOS/iOS-Base.xcconfig
@@ -7,7 +7,7 @@
 // Architectures to build
 // Xcode 5 doesn't know about ARCHS_STANDARD_32_BIT
 // And Xcode 4 doesn't know about ARCHS_STANDARD
-ARCHS = armv7 armv7s
+ARCHS = armv7 armv7s arm64
 
 // Whether to only build the active architecture (overridden from Debug/Profile)
 ONLY_ACTIVE_ARCH = NO


### PR DESCRIPTION
Without this there will be no 64-bit symbols in the resulting product. This is backwards-compatible as long as you are using Xcode 5.0.1+ and targeting iOS 5.1.1+.

The underlying motivation for this is that I cannot currently build Mantle for 64-bit iOS unless I manually modify the Mantle Xcode project.
