### PR TITLE
Removed duplicate build setting

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -56,9 +56,6 @@ CLANG_WARN_OBJC_ROOT_CLASS = YES
 // Whether to warn on suspicious implicit conversions
 CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 
-// Warn if a variable might be clobbered by a setjmp call or if an automatic variable is used without prior initialization.
-GCC_WARN_UNINITIALIZED_AUTOS = YES
-
 // The format of debugging symbols
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 
@@ -139,6 +136,9 @@ GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
 
 // Warn if a "@selector(...)" expression referring to an undeclared selector is found
 GCC_WARN_UNDECLARED_SELECTOR = YES
+
+// Warn if a variable might be clobbered by a setjmp call or if an automatic variable is used without prior initialization.
+GCC_WARN_UNINITIALIZED_AUTOS = YES
 
 // Whether to warn about static functions that are unused
 GCC_WARN_UNUSED_FUNCTION = YES


### PR DESCRIPTION
`GCC_WARN_UNINITIALIZED_AUTOS = YES` only needs to be declared once, unless it's one of those mythical beasts where it should really be `GCC_WARN_UNINITIALIZED_AUTOS = YES_FOR_REAL_THIS_TIME`

For verification, both of the duplicates are at:
https://github.com/jspahrsummers/xcconfigs/blob/4a00c43bc2b9bb5d6dc57f315bb822f487e5387b/Base/Common.xcconfig#L60
https://github.com/jspahrsummers/xcconfigs/blob/4a00c43bc2b9bb5d6dc57f315bb822f487e5387b/Base/Common.xcconfig#L144

:two_hearts: 
