### PR TITLE
Unused static const variables need not complain

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -155,8 +155,8 @@ RUN_CLANG_STATIC_ANALYZER = YES
 // Whether to run unit tests with every build
 TEST_AFTER_BUILD = NO
 
-// Disable GCC compatibility warnings
-WARNING_CFLAGS = -Wno-gcc-compat
+// Disable GCC compatibility warnings and unused static const variable warnings
+WARNING_CFLAGS = -Wno-gcc-compat -Wno-unused-const-variable
 
 // Disable legacy-compatible header searching
 ALWAYS_SEARCH_USER_PATHS = NO


### PR DESCRIPTION
This was biting us in cases where a release configuration was using the static variables and a debug one was not. This was considered preferable to `__attribute__((used))` on the variables in question or some other workaround.
