### PR TITLE
Treat unknown-warning-option as a warning not an error

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -155,8 +155,8 @@ RUN_CLANG_STATIC_ANALYZER = YES
 // Whether to run unit tests with every build
 TEST_AFTER_BUILD = NO
 
-// Disable GCC compatibility warnings and unused static const variable warnings
-WARNING_CFLAGS = -Wno-gcc-compat -Wno-unused-const-variable
+// Don't treat unknown warnings as errors, and disable GCC compatibility warnings and unused static const variable warnings
+WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable
 
 // Disable legacy-compatible header searching
 ALWAYS_SEARCH_USER_PATHS = NO


### PR DESCRIPTION
For dat Xcode 5 backwards compatibility.

Xcode 5's clang version doesn't recognise `-Wno-unused-const-variable` and since we have `-Werror` turned on, it's an error. :rage:

This adds `-Wno-error=unknown-warning-option` so that unknown options stay as warnings.
