### PR TITLE
In Test, inherit --timestamp=none from Debug

### DIFF
--- a/Base/Configurations/Test.xcconfig
+++ b/Base/Configurations/Test.xcconfig
@@ -8,6 +8,3 @@
 // Sandboxed apps can't be unit tested since they can't load some random 
 // external bundle. So we disable sandboxing for testing.
 CODE_SIGN_ENTITLEMENTS = 
-
-// Disable Developer ID timestamping
-OTHER_CODE_SIGN_FLAGS = --timestamp=none


### PR DESCRIPTION
Just reducing duplication.

/cc @keithduncan 
