### PR TITLE
Remove USER_HEADER_SEARCH_PATHS default

### DIFF
--- a/Base/Targets/Framework.xcconfig
+++ b/Base/Targets/Framework.xcconfig
@@ -24,8 +24,3 @@ PRODUCT_NAME = $(PROJECT_NAME)
 INSTALL_PATH = @rpath
 LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
 SKIP_INSTALL = YES
-
-// When compiling this library, look for imports (written with quotes) in the
-// library's own folder first. This avoids conflicts from other headers in the
-// build folder.
-USER_HEADER_SEARCH_PATHS = ./**

--- a/Base/Targets/StaticLibrary.xcconfig
+++ b/Base/Targets/StaticLibrary.xcconfig
@@ -22,10 +22,5 @@ GCC_DYNAMIC_NO_PIC = NO
 // libraries
 PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME
 
-// When compiling this library, look for imports (written with quotes) in the
-// library's own folder first. This avoids conflicts from other headers in the
-// build folder.
-USER_HEADER_SEARCH_PATHS = ./**
-
 // Don't include in an xcarchive
 SKIP_INSTALL = YES


### PR DESCRIPTION
This can cause huge argument lists, potentially even resulting in a build failure. It seems more appropriate per-project on the occasion that it’s even needed.
