### PR TITLE
Turn off nullability-completeness warnings.

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -171,4 +171,4 @@ GCC_WARN_UNUSED_VARIABLE = YES
 RUN_CLANG_STATIC_ANALYZER = YES
 
 // Don't treat unknown warnings as errors, and disable GCC compatibility warnings and unused static const variable warnings
-WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable
+WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable -Wno-nullability-completeness


### PR DESCRIPTION
While these warnings enable better integration with Swift, Swift itself doesn’t produce the relevant annotations in its header, which breaks the build.