### PR TITLE
Framework.xcconfig: setting APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/Base/Targets/Framework.xcconfig
+++ b/Base/Targets/Framework.xcconfig
@@ -24,3 +24,9 @@ PRODUCT_NAME = $(PROJECT_NAME)
 INSTALL_PATH = @rpath
 LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
 SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES
+

--- a/Base/Targets/StaticLibrary.xcconfig
+++ b/Base/Targets/StaticLibrary.xcconfig
@@ -24,3 +24,9 @@ PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME
 
 // Don't include in an xcarchive
 SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES
+


### PR DESCRIPTION
Per the documentation:

```
When enabled, this causes the compiler and linker to
disallow use of APIs that are not available to
app extensions and to disallow linking to frameworks
that have not been built with this setting enabled.
```

This allows frameworks to be linked safely from extensions.