### PR TITLE
Ignore Carthage/Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Carthage/Build


### PR DESCRIPTION
When using this project as a dependency of a framework being built with [Carthage](https://github.com/Carthage/Carthage) in mind you always en up with `untracked content` changes that could be cleaned up just by ignoring `Carthage/Build`