### PR TITLE
Enable Whole Module Optimization in Release by default

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -39,5 +39,8 @@ STRIP_INSTALLED_PRODUCT = NO
 // The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 
+// Whether to optimize across the whole Swift module
+SWIFT_WHOLE_MODULE_OPTIMIZATION = NO
+
 // Disable Developer ID timestamping
 OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -30,7 +30,7 @@ STRIP_INSTALLED_PRODUCT = YES
 SWIFT_OPTIMIZATION_LEVEL = -O
 
 // Whether to optimize across the whole Swift module
-SWIFT_WHOLE_MODULE_OPTIMIZATION = NO
+SWIFT_WHOLE_MODULE_OPTIMIZATION = YES
 
 // Whether to perform App Store validation checks
 VALIDATE_PRODUCT = YES

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -29,5 +29,9 @@ STRIP_INSTALLED_PRODUCT = YES
 // The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -O
 
+// Whether to optimize across the whole Swift module
+SWIFT_WHOLE_MODULE_OPTIMIZATION = NO
+
 // Whether to perform App Store validation checks
 VALIDATE_PRODUCT = YES
+


### PR DESCRIPTION
I don't know if the build setting can really be considered as stable, but disabling it seems like a decision to be made at the project level.

By default, I think it makes sense for Release to enable Apple's reasonable optimizations.