### PR TITLE
Setting SWIFT_WHOLE_MODULE_OPTIMIZATION

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -39,5 +39,8 @@ STRIP_INSTALLED_PRODUCT = NO
 // The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 
+// Enable optimization across all Swift files in the module.
+SWIFT_WHOLE_MODULE_OPTIMIZATION = NO
+
 // Disable Developer ID timestamping
 OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -29,5 +29,8 @@ STRIP_INSTALLED_PRODUCT = YES
 // The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -O
 
+// Enable optimization across all Swift files in the module.
+SWIFT_WHOLE_MODULE_OPTIMIZATION = YES
+
 // Whether to perform App Store validation checks
 VALIDATE_PRODUCT = YES


### PR DESCRIPTION
`NO` for Debug and `YES` for Release.

I noticed these were manually configured in ReactiveCocoa's target.