### PR TITLE
Updated SWIFT_OPTIMIZATION_LEVEL for Swift 2

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -39,8 +39,5 @@ STRIP_INSTALLED_PRODUCT = NO
 // The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 
-// Whether to optimize across the whole Swift module
-SWIFT_WHOLE_MODULE_OPTIMIZATION = NO
-
 // Disable Developer ID timestamping
 OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -26,11 +26,8 @@ ONLY_ACTIVE_ARCH = NO
 // final installation location
 STRIP_INSTALLED_PRODUCT = YES
 
-// The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
-SWIFT_OPTIMIZATION_LEVEL = -O
-
-// Whether to optimize across the whole Swift module
-SWIFT_WHOLE_MODULE_OPTIMIZATION = YES
+// The optimization level (-Onone, -O, -Owholemodule) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
 
 // Whether to perform App Store validation checks
 VALIDATE_PRODUCT = YES


### PR DESCRIPTION
Swift 2 has unified `SWIFT_OPTIMIZATION_LEVEL` and `SWIFT_WHOLE_MODULE_OPTIMIZATION`, so I've removed the later, and set `Release` to `-Owholemodule`.