### PR TITLE
Enabling bitcode for Frameworks and setting BITCODE_GENERATION_MODE to bitcode (fixes #45)

### DIFF
--- a/Base/Targets/Framework.xcconfig
+++ b/Base/Targets/Framework.xcconfig
@@ -30,3 +30,6 @@ SKIP_INSTALL = YES
 // that have not been built with this setting enabled.
 APPLICATION_EXTENSION_API_ONLY = YES
 
+ENABLE_BITCODE = YES;
+// See https://github.com/Carthage/Carthage/issues/535 for details:
+BITCODE_GENERATION_MODE = bitcode;


### PR DESCRIPTION
This enables frameworks to support Bitcode when built with Carthage (which uses `build` instead of `archive`).
See https://github.com/Carthage/Carthage/issues/535 for more details.