### PR TITLE
Always enable bitcode for tvOS and watchOS 2

### DIFF
--- a/tvOS/tvOS-Base.xcconfig
+++ b/tvOS/tvOS-Base.xcconfig
@@ -13,3 +13,6 @@ SDKROOT = appletvos
 
 // Supported device families
 TARGETED_DEVICE_FAMILY = 3
+
+// Mandatory for tvOS
+ENABLE_BITCODE = YES

--- a/watchOS/watchOS-Base.xcconfig
+++ b/watchOS/watchOS-Base.xcconfig
@@ -13,3 +13,6 @@ SDKROOT = watchos
 
 // Supported device families
 TARGETED_DEVICE_FAMILY = 4
+
+// Mandatory for watchOS 2
+ENABLE_BITCODE = YES


### PR DESCRIPTION
I recently set up a couple of new projects and I realized that Xcode still doesn't add this by default on targets for these platforms. What's worst: it's not trivial to enable! You have to enter the setting by hand in "User-Defined" settings... :walking: 

Since this is mandatory, I think it's better to just have this here :)

I know we talked about this @jspahrsummers, but let me know what you think!