### PR TITLE
Separate LD_RUNPATH_SEARCH_PATHS into Mac-Application and Mac-Framework

### DIFF
--- a/Mac OS X/Mac-Application.xcconfig
+++ b/Mac OS X/Mac-Application.xcconfig
@@ -13,3 +13,9 @@
 // Whether function calls should be position-dependent (should always be
 // disabled for library code)
 GCC_DYNAMIC_NO_PIC = YES
+
+// Where to find embedded frameworks
+// Search `Frameworks` in the .app.
+// If app is cli at `/usr/local/bin/foo`, `@executable_path/../Frameworks`
+// means `/usr/local/Frameworks`.
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks

--- a/Mac OS X/Mac-Base.xcconfig
+++ b/Mac OS X/Mac-Base.xcconfig
@@ -8,9 +8,6 @@
 // TIFF
 COMBINE_HIDPI_IMAGES = YES
 
-// Where to find embedded frameworks
-LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks
-
 // The base SDK to use (if no version is specified, the latest version is
 // assumed)
 SDKROOT = macosx

--- a/Mac OS X/Mac-Framework.xcconfig
+++ b/Mac OS X/Mac-Framework.xcconfig
@@ -9,3 +9,9 @@
 
 // Import common settings specific to Mac OS X
 #include "Mac-Base.xcconfig"
+
+// Where to find embedded frameworks.
+// First search `Frameworks` in the .framework, then one in the .app.
+// If app is cli at `/usr/local/bin/foo`, `@executable_path/../Frameworks`
+// means `/usr/local/Frameworks`.
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/../Frameworks


### PR DESCRIPTION
### Framework

Adding searching sub-frameworks path to framework target.  
Based on framework target template of Xcode as following:

```
LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/../Frameworks
```

modified for searching sub-framework first.
### App

Remove searching `@loader_path/../Frameworks` from Mac App target.
As same as Mac App target template of Xcode.
Relating to https://github.com/Carthage/Carthage/pull/938
