### PR TITLE
Disable automatic module linking

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -22,6 +22,10 @@ CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES
 // Whether to enable module imports
 CLANG_ENABLE_MODULES = YES
 
+// Whether to automatically link imported modules.
+// Set to NO here as the feature leads to accidental linking with other modules.
+CLANG_MODULES_AUTOLINK = NO
+
 // Enable ARC
 CLANG_ENABLE_OBJC_ARC = YES
 


### PR DESCRIPTION
This PR disables automatically linking modules on import using the `import` statement in Swift or the corresponding `#import/#include` in Objective-C. Automatically linking modules have a tendency to create accidental, and hidden, strong dependencies between modules. Where a dependency was not actually wanted.

Declaring ones dependences explicitly instead (by adding it to the “link with” build phase) is to be preferred in my opinion.

One caveat to merging this change is that it would break the build of any project which depends on automatic linking. Since this is currently the default in Xcode that might be quite a few project. So tread carefully when making the decision whether to merge or not.