### PR TITLE
Fix comments about watchOS in tvOS configs

### DIFF
--- a/tvOS/tvOS-Application.xcconfig
+++ b/tvOS/tvOS-Application.xcconfig
@@ -1,11 +1,11 @@
 //
 // This file defines additional configuration options that are appropriate only
-// for an application on watchOS. This should be set at the target level for
+// for an application on tvOS. This should be set at the target level for
 // each project configuration.
 //
 
 // Import base application settings
 #include "../Base/Targets/Application.xcconfig"
 
-// Apply common settings specific to watchOS
+// Apply common settings specific to tvOS
 #include "tvOS-Base.xcconfig"

--- a/tvOS/tvOS-Base.xcconfig
+++ b/tvOS/tvOS-Base.xcconfig
@@ -1,6 +1,6 @@
 //
 // This file defines additional configuration options that are appropriate only
-// for watchOS. This file is not standalone -- it is meant to be included into
+// for tvOS. This file is not standalone -- it is meant to be included into
 // a configuration file for a specific type of target.
 //
 

--- a/tvOS/tvOS-Framework.xcconfig
+++ b/tvOS/tvOS-Framework.xcconfig
@@ -1,6 +1,6 @@
 //
 // This file defines additional configuration options that are appropriate only
-// for a framework on watchOS. This should be set at the target level for each
+// for a framework on tvOS. This should be set at the target level for each
 // project configuration.
 //
 

--- a/tvOS/tvOS-StaticLibrary.xcconfig
+++ b/tvOS/tvOS-StaticLibrary.xcconfig
@@ -1,11 +1,11 @@
 //
 // This file defines additional configuration options that are appropriate only
-// for a static library on watchOS. This should be set at the target level for
+// for a static library on tvOS. This should be set at the target level for
 // each project configuration.
 //
 
 // Import base static library settings
 #include "../Base/Targets/StaticLibrary.xcconfig"
 
-// Apply common settings specific to watchOS
+// Apply common settings specific to tvOS
 #include "tvOS-Base.xcconfig"


### PR DESCRIPTION
I noticed several comments in the tvOS configs that look like carry over from the watchOS configs they were copied from.  This pull requests updates those comments to reference tvOS instead of watchOS.