### PR TITLE
Add warnings new in Xcode 8 beta 5.

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -177,3 +177,11 @@ WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-c
 // the default. It warns if the same variable is declared in two binaries that
 // are linked together.
 GCC_NO_COMMON_BLOCKS = YES
+
+// This warnings detects when a function will recursively call itself on every
+// code path though that function. More information can be found here:
+// http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20131216/096004.html
+CLANG_WARN_INFINITE_RECURSION = YES
+
+// This warning detects suspicious uses of std::move.
+CLANG_WARN_SUSPICIOUS_MOVE = YES


### PR DESCRIPTION
- Add `CLANG_WARN_INFINITE_RECURSION` to `Base.xcconfigs`
- Add `CLANG_WARN_SUSPICIOUS_MOVE` to `Base.xcconfigs`