### PR TITLE
Enable testability for Debug and Test configurations

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -15,7 +15,7 @@ GCC_OPTIMIZATION_LEVEL = 0
 // Preproccessor definitions to apply to each file compiled
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1
 
-// Allow testing
+// Allow @testable imports
 ENABLE_TESTABILITY = YES
 
 // Whether to enable link-time optimizations (such as inlining across translation

--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -15,6 +15,9 @@ GCC_OPTIMIZATION_LEVEL = 0
 // Preproccessor definitions to apply to each file compiled
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1
 
+// Allow testing
+ENABLE_TESTABILITY = YES
+
 // Whether to enable link-time optimizations (such as inlining across translation
 // units)
 LLVM_LTO = NO

--- a/Base/Configurations/Test.xcconfig
+++ b/Base/Configurations/Test.xcconfig
@@ -9,5 +9,5 @@
 // external bundle. So we disable sandboxing for testing.
 CODE_SIGN_ENTITLEMENTS = 
 
-// Allow testing
+// Allow @testable imports
 ENABLE_TESTABILITY = YES

--- a/Base/Configurations/Test.xcconfig
+++ b/Base/Configurations/Test.xcconfig
@@ -8,3 +8,6 @@
 // Sandboxed apps can't be unit tested since they can't load some random 
 // external bundle. So we disable sandboxing for testing.
 CODE_SIGN_ENTITLEMENTS = 
+
+// Allow testing
+ENABLE_TESTABILITY = YES


### PR DESCRIPTION
It should be enabled for the Test configuration.
Given not everyone has a Test configuration and Xcode's warning
to enable it for Debug builds as well, I'd say let's go with it.

refs #54