### PR TITLE
enable CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION

### DIFF
--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -71,6 +71,9 @@ CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 // Warn about incorrect uses of nullable values
 CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
 
+// Warn for missing nullability attributes
+CLANG_ANALYZER_NONNULL = YES
+
 // Warn about potentially unreachable code
 CLANG_WARN_UNREACHABLE_CODE = YES
 

--- a/Base/Common.xcconfig
+++ b/Base/Common.xcconfig
@@ -68,6 +68,9 @@ CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
 // Whether to warn on suspicious implicit conversions
 CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 
+// Warn about incorrect uses of nullable values
+CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
+
 // Warn about potentially unreachable code
 CLANG_WARN_UNREACHABLE_CODE = YES
 


### PR DESCRIPTION
This is connected to #67 and enables warnings when possible `nil` values are passed to `nonnull` parameters