### PR TITLE
enable debug-time-function-bodies for Debug config

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -33,7 +33,7 @@ OTHER_CFLAGS = -ftrapv
 // Other flags to pass to the Swift compiler
 //
 // This enables conditional compilation with #if DEBUG
-OTHER_SWIFT_FLAGS = -D DEBUG
+OTHER_SWIFT_FLAGS = -D DEBUG -Xfrontend -debug-time-function-bodies
 
 // Xcode 8 introduced a new flag for conditional compilation
 //


### PR DESCRIPTION
allows to analyze compile time of swift code.

http://irace.me/swift-profiling
https://github.com/RobertGummesson/BuildTimeAnalyzer-for-Xcode