### PR TITLE
Add configurations for iOS extensions

### DIFF
--- a/Base/Targets/Extension.xcconfig
+++ b/Base/Targets/Extension.xcconfig
@@ -1,0 +1,8 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an extension embedded within an application. Typically, you want to use a
+// platform-specific variant instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO

--- a/iOS/iOS-Extension.xcconfig
+++ b/iOS/iOS-Extension.xcconfig
@@ -1,0 +1,23 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an extension embedded within an application on iOS. This should be set at
+// the target level for each project configuration.
+//
+
+// Import base extension settings
+#include "../Base/Targets/Extension.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"
+
+// Sets the @rpath for the application such that it can include frameworks in
+// the application bundle two levels up, inside the "Frameworks" folder.
+//
+// Does not search the frameworks folder at the same level as the extension
+// executable since extensions with their own embedded frameworks are rejected
+// with the following error:
+//
+// > Invalid Bundle. The bundle at 'App.app/PlugIns/Extension.appex' contains
+// > disallowed file 'Frameworks'
+//
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../../Frameworks


### PR DESCRIPTION
iOS extensions (e.g. today widgets) should have specific settings for `LD_RUNPATH_SEARCH_PATHS`. Specifically, they should only search for frameworks embedded within their containing app’s bundle.

I’m not entirely sure of what the corresponding value would be for macOS without trying out an example project. If anyone knows off of the top of their head, I’d be more than happy to append them here.