### PR TITLE
Remove @loader_path search path for applications

### DIFF
--- a/iOS/iOS-Application.xcconfig
+++ b/iOS/iOS-Application.xcconfig
@@ -9,3 +9,6 @@
 
 // Apply common settings specific to iOS
 #include "iOS-Base.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks


### PR DESCRIPTION
This setting is the Xcode default when creating new projects.

This setting was previously set to:

```
LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
```

As resolved from the `iOS-Base.xcconfig` file when using the `iOS-Application.xcconfig` configuration. As far as I can tell, using `@loader_path/Frameworks` is only necessary from within Fameworks.