### PR TITLE
accept ARM as valid archs for Apple Silicon Macs

### DIFF
--- a/macOS/macOS-Base.xcconfig
+++ b/macOS/macOS-Base.xcconfig
@@ -13,4 +13,4 @@ COMBINE_HIDPI_IMAGES = YES
 SDKROOT = macosx
 
 // Supported build architectures
-VALID_ARCHS = x86_64
+VALID_ARCHS = arm64 arm64e i386 x86_64


### PR DESCRIPTION
The values are copied straight from standard Xcode build settings.